### PR TITLE
Add campaign based opt outs.

### DIFF
--- a/snippets/base/templates/base/includes/snippet_js.html
+++ b/snippets/base/templates/base/includes/snippet_js.html
@@ -248,7 +248,10 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         var blockList = getBlockList();
         snippets = snippets.filter(
             function (snippet) {
-                if (blockList.indexOf(snippet.id) === -1) {
+                var snippet_id = parseInt(snippet.id, 10);
+                var campaign = snippet.campaign;
+                var snippetHandle = campaign || snippet_id;
+                if (blockList.indexOf(snippetHandle) === -1) {
                     return true;
                 }
                 return false;
@@ -425,10 +428,15 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
 
     // Add links to buttons that block snippets.
     function addSnippetBlockLinks(elements) {
-        var snippet_id = ABOUTHOME_SHOWN_SNIPPET.id;
+        var snippet_id = parseInt(ABOUTHOME_SHOWN_SNIPPET.id, 10);
+        var campaign = ABOUTHOME_SHOWN_SNIPPET.campaign;
+        var snippetHandle = campaign || snippet_id;
+        if (!snippetHandle && snippetHandle !== 0) {
+            return;
+        }
         var blockSnippet = function (event) {
             event.preventDefault();
-            addToBlockList(snippet_id);
+            addToBlockList(snippetHandle);
             sendMetric('snippet-blocked', function() { window.location.reload(); })
         };
 
@@ -544,18 +552,17 @@ function sendMetric(metric, callback) {
     {% endif %}
 }
 
-function popFromBlockList(snippetID) {
+function popFromBlockList(snippetHandle) {
     var blockList = getBlockList();
-    var item = blockList.pop(snippetID);
+    var item = blockList.pop(snippetHandle);
     gSnippetsMap.set('blockList', blockList);
     return item;
 }
 
-function addToBlockList(snippetID) {
+function addToBlockList(snippetHandle) {
     var blockList = getBlockList();
-    snippetID = parseInt(snippetID, 10);
-    if (blockList.indexOf(snippetID) === -1) {
-        blockList = [snippetID].concat(blockList);
+    if (blockList.indexOf(snippetHandle) === -1) {
+        blockList = [snippetHandle].concat(blockList);
         gSnippetsMap.set('blockList', blockList);
     }
 }


### PR DESCRIPTION
Playing around a bit.

I notice there was a campaign prop in the snippet service, so I was wondering if we could use that to get better opt out surface area. Code was fairly simple so I provided that as an example.

Example, a snippet with no campaign is opt'ed out, so it uses the id. However, if a campaign is present, example "2015-eoy", it opts me out of all snippets under that campaign name.

I'm not super familiar with the historical usage of the campaign name, and I see a potential issue in a campaign name being re used by accident. As it's not an ID and nothing is forcing it to be unique, that I know of. Looks like currently it's used for metrics.
