### PR TITLE
Make ESR channel follow Release channel.

### DIFF
--- a/snippets/base/managers.py
+++ b/snippets/base/managers.py
@@ -47,8 +47,13 @@ class SnippetQuerySet(CachingQuerySet):
 
         # Retrieve the first channel that starts with the client's channel.
         # Allows things like "release-cck-mozilla14" to match "release".
-        client_channel = ('nightly' if client.channel == 'default'
-                          else first(CHANNELS, client.channel.startswith))
+        if client.channel == 'default':
+            client_channel = 'nightly'
+        elif client.channel == 'esr':
+            client_channel = 'release'
+        else:
+            client_channel = first(CHANNELS, client.channel.startswith)
+
         if client_channel:
             filters.update(**{'on_{0}'.format(client_channel): True})
 

--- a/snippets/base/tests/test_managers.py
+++ b/snippets/base/tests/test_managers.py
@@ -226,3 +226,22 @@ class SnippetManagerTests(TestCase):
         # are the same snippets. Just `nightly_snippet` in this case.
         self.assertEqual(set([nightly_snippet]), set(nightly_snippets))
         self.assertEqual(set([nightly_snippet]), set(default_snippets))
+
+    def test_esr_is_same_as_release(self):
+        """ Make sure that esr channel follows release. """
+        # Snippets matching nightly (and therefor should match default).
+        release_snippet = SnippetFactory.create(on_release=True)
+
+        # Snippets that don't match nightly
+        SnippetFactory.create(on_release=False, on_beta=True)
+
+        release_client = self._build_client(channel='release')
+        release_snippets = Snippet.cached_objects.match_client(release_client)
+
+        esr_client = self._build_client(channel='esr')
+        esr_snippets = Snippet.cached_objects.match_client(esr_client)
+
+        # Assert that both the snippets returned from release and from esr
+        # are the same snippets. Just `release_snippet` in this case.
+        self.assertEqual(set([release_snippet]), set(release_snippets))
+        self.assertEqual(set([release_snippet]), set(esr_snippets))


### PR DESCRIPTION
By reading HTTP logs we figured that ESR versions report ESR channel instead of release. With this patch we're treating ESRs as Release.

@pmac r?