### PR TITLE
Separate deploys to EUW and USW clusters with tags.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,13 +71,16 @@ deploy:
     on:
       tags: true
       repo: mozmar/snippets-service
+      condition: $(echo ${TRAVIS_TAG} | egrep "^201[6-9][0-9]{4}.[0-9]+.usw")
   - provider: script
     script: bin/deploy-travis.sh $DEIS_CONTROLLER_US_WEST $DEIS_PROD_APPLICATION $NEWRELIC_US_WEST_PROD_APPLICATION
     on:
       tags: true
       repo: mozmar/snippets-service
+      condition: $(echo ${TRAVIS_TAG} | egrep "^201[6-9][0-9]{4}.[0-9]+.usw")
   - provider: script
     script: bin/deploy-travis.sh $DEIS_CONTROLLER_EU_WEST $DEIS_PROD_APPLICATION $NEWRELIC_EU_WEST_PROD_APPLICATION
     on:
       tags: true
       repo: mozmar/snippets-service
+      condition: $(echo ${TRAVIS_TAG} | egrep "^201[6-9][0-9]{4}.[0-9]+.euw")


### PR DESCRIPTION
Use different tag format to distinct deploys to EUW and USW clusters.
Tags ending with usw will deploy only to USW and tags ending with euw
will deploy only to EUW.

Also limit deployments to tags matching YYYYMMDD.XX.DDD format where XX
is sequential number of tag for the day starting at 1 (thus 1,2,3...)
and DDD is `usw` or `euw`.

This has been tested against [glogiotatidis/condition-test](https://github.com/glogiotatidis/condition-test/releases). [Travis builds](https://travis-ci.org/glogiotatidis/condition-test/builds)