### PR TITLE
Add extra tags to sentry report.

### DIFF
--- a/snippets/settings.py
+++ b/snippets/settings.py
@@ -299,6 +299,11 @@ STATSD_CLIENT = config('STATSD_CLIENT', 'django_statsd.clients.null')
 RAVEN_CONFIG = {
     'dsn': config('SENTRY_DSN', None),
     'release': config('GIT_SHA', None),
+    'tags': {
+        'server_full_name': '.'.join(x for x in [HOSTNAME, DEIS_APP, DEIS_DOMAIN] if x),
+        'environment': config('SENTRY_ENVIRONMENT', ''),
+        'site': '.'.join(x for x in [DEIS_APP, DEIS_DOMAIN] if x),
+    }
 }
 
 ALTERNATE_METRICS_URL = config('ALTERNATE_METRICS_URL', default=None)


### PR DESCRIPTION
Extra tags:
 - server_full_name
 - environment
 - site

This those extra tags we will able to merge all Sentry apps into one for easier
managements on multiple clusters.