### PR TITLE
Add OVERRIDE_MARIADB_VERSION to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,6 @@ web:
     - DEBUG=True
     - ALLOWED_HOSTS=localhost,127.0.0.1,
     - SECRET_KEY=59114b6a-2858-4caf-8878-482a24ee9542
+    - OVERRIDE_MARIADB_VERSION="(10, 1, 22)"
   command:
     ./bin/run-dev.sh


### PR DESCRIPTION
Use version matching current latest tag

See https://github.com/mozmar/snippets-service/commit/32fb34b7e5536875f75e1a492e8a3d88f80eb8d3 for more details