### PR TITLE
[bug 1372847] Filter snippets based on profile age.

### DIFF
--- a/snippets/base/admin.py
+++ b/snippets/base/admin.py
@@ -184,6 +184,8 @@ class SnippetAdmin(BaseSnippetAdmin):
                 'client_option_has_testpilot',
                 'client_option_is_default_browser',
                 'client_option_screen_resolutions',
+                'client_option_profileage_lower_bound',
+                'client_option_profileage_upper_bound',
             )
         }),
         ('Country and Locale', {

--- a/snippets/base/migrations/0018_auto_20170614_0925.py
+++ b/snippets/base/migrations/0018_auto_20170614_0925.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+from django_mysql.models.functions import AsType, ColumnAdd
+
+
+def set_default_bounds_for_profileage(apps, schema_editor):
+    Snippet = apps.get_model('base', 'Snippet')
+    Snippet.objects.update(
+        client_options=ColumnAdd('client_options',
+                                 {'profileage_lower_bound': AsType(-1, 'INTEGER')})
+    )
+    Snippet.objects.update(
+        client_options=ColumnAdd('client_options',
+                                 {'profileage_upper_bound': AsType(-1, 'INTEGER')})
+    )
+
+
+def noop(apps, schema_editor):
+    # nothing needed to go back in time.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0017_auto_20170609_1246'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_default_bounds_for_profileage, noop)
+    ]

--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -406,6 +406,8 @@ class Snippet(CachingMixin, SnippetBaseModel):
             'has_testpilot': unicode,
             'is_default_browser': unicode,
             'screen_resolutions': unicode,
+            'profileage_lower_bound': int,
+            'profileage_upper_bound': int,
         }
     )
 

--- a/snippets/base/templates/base/includes/snippet.js
+++ b/snippets/base/templates/base/includes/snippet.js
@@ -170,11 +170,11 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
     // Update FxAccount Status
     updateFxAccountStatus();
 
-    // Update Default Browser Status
-    updateDefaultBrowserStatus();
-
     // Update Selected Search Engine
     updateSelectedSearchEngine();
+
+    // Get appinfo from UITour
+    updateAppInfoStatus();
 
     // Fetch user country if we don't have it.
     if (!haveUserCountry()) {
@@ -189,6 +189,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
     // Choose which snippet to display to the user based on various factors,
     // such as which country they are in.
     function chooseSnippet(snippets) {
+
         USER_COUNTRY = getUserCountry();
         if (USER_COUNTRY) {
             snippets = snippets.filter(
@@ -208,7 +209,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
                 function(snippet) {
                     return snippet.countries.length === 0;
                 }
-            )
+            );
         }
 
         // Filter Snippets based on the has_fxaccount attribute.
@@ -219,7 +220,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
                     return (snippet.client_options.has_fxaccount == 'yes' ||
                             snippet.client_options.has_fxaccount == 'any');
                 }
-            )
+            );
         } else if (has_fxaccount === false) {
             snippets = snippets.filter(
                 function(snippet) {
@@ -243,7 +244,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
                     return (snippet.client_options.has_testpilot == 'yes' ||
                             snippet.client_options.has_testpilot == 'any');
                 }
-            )
+            );
         } else {
             snippets = snippets.filter(
                 function(snippet) {
@@ -254,14 +255,14 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         }
 
         // Filter Snippets based on whether Firefox is the default browser or now.
-        var is_default_browser = gSnippetsMap.get('is_default_browser');
-        if (is_default_browser === true || is_default_browser === undefined) {
+        var appInfo = gSnippetsMap.get('appInfo');
+        if (appInfo && (appInfo.defaultBrowser === true || appInfo.defaultBrowser === undefined)) {
             snippets = snippets.filter(
                 function(snippet) {
                     return (snippet.client_options.is_default_browser == 'yes' ||
                             snippet.client_options.is_default_browser == 'any');
                 }
-            )
+            );
         } else {
             snippets = snippets.filter(
                 function(snippet) {
@@ -371,7 +372,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
     function updateFxAccountStatus() {
         var callback = function(result) {
             gSnippetsMap.set('fxaccount', result.setup);
-        }
+        };
         var event = new CustomEvent(
             'mozUITour', {
                 bubbles: true,
@@ -387,10 +388,10 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         document.dispatchEvent(event);
     }
 
-    function updateDefaultBrowserStatus() {
+    function updateAppInfoStatus() {
         var callback = function(result) {
-            gSnippetsMap.set('is_default_browser', result.defaultBrowser);
-        }
+            gSnippetsMap.set('appInfo', result);
+        };
         var event = new CustomEvent(
             'mozUITour', {
                 bubbles: true,
@@ -409,7 +410,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
     function updateSelectedSearchEngine() {
         var callback = function(result) {
             gSnippetsMap.set('selectedSearchEngine', result.searchEngineIdentifier);
-        }
+        };
         var event = new CustomEvent(
             'mozUITour', {
                 bubbles: true,

--- a/snippets/base/templates/base/includes/snippet.js
+++ b/snippets/base/templates/base/includes/snippet.js
@@ -189,7 +189,6 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
     // Choose which snippet to display to the user based on various factors,
     // such as which country they are in.
     function chooseSnippet(snippets) {
-
         USER_COUNTRY = getUserCountry();
         if (USER_COUNTRY) {
             snippets = snippets.filter(
@@ -336,6 +335,40 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
                 return display;
             }
         );
+
+        // Filter based on Profile age
+        //
+        // appInfo.profileCreatedWeeksAgo can be either undefined for Firefox
+        // versions that don't expose this information, or a number >= 0.
+        if (appInfo && appInfo.profileCreatedWeeksAgo !== undefined) {
+            let profileAge = appInfo.profileCreatedWeeksAgo;
+            snippets = snippets.filter(
+                function(snippet) {
+                    let lower_bound = snippet.client_options.profileage_lower_bound;
+                    let upper_bound = snippet.client_options.profileage_upper_bound;
+                    if (lower_bound > -1 && profileAge < lower_bound) {
+                        return false;
+                    }
+                    if (upper_bound > -1 && profileAge >= upper_bound) {
+                        return false;
+                    }
+                    return true;
+                }
+            );
+        }
+        else {
+            // Remove all snippets that use profile age since this information
+            // is not available.
+            snippets = snippets.filter(
+                function(snippet) {
+                    if (snippet.client_options.profileage_lower_bound > -1
+                        || snippet.client_options.profileage_upper_bound > -1) {
+                        return false;
+                    }
+                    return true;
+                }
+            );
+        }
 
         // Exclude snippets in block list.
         var blockList = getBlockList();

--- a/snippets/base/validators.py
+++ b/snippets/base/validators.py
@@ -1,0 +1,11 @@
+from django.core.validators import BaseValidator
+from django.utils.deconstruct import deconstructible
+
+
+@deconstructible
+class MinValueValidator(BaseValidator):
+    message = 'Ensure this value is greater than or equal to %(limit_value)s.'
+    code = 'min_value'
+
+    def compare(self, a, b):
+        return int(a) < int(b)


### PR DESCRIPTION
This PR enables filtering based on Firefox Profile Age information exposed to UITour via bug [1343510](https://bugzilla.mozilla.org/show_bug.cgi?id=1343510). Includes changes in the Admin interface ([Screenshot](https://user-images.githubusercontent.com/584352/27901074-5ae743d2-6239-11e7-8840-69203b7bfbfe.png)) and the needed client side JS changes on the snippet selection decision engine.

- [x] Check migration version before merging: update may be needed due to other PRs getting merged first.



