### PR TITLE
Submit results to the correct repository in Treeherder

### DIFF
--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
           archiveArtifacts 'tests/results/*'
           junit 'tests/results/*.xml'
           submitToActiveData('tests/results/py27_raw.txt')
-          submitToTreeherder('snippets-tests', 'e2e', 'End-to-end integration tests', 'tests/results/*', 'tests/results/py27_tbpl.txt')
+          submitToTreeherder('snippets-service', 'e2e', 'End-to-end integration tests', 'tests/results/*', 'tests/results/py27_tbpl.txt')
         }
       }
     }


### PR DESCRIPTION
The results aren't currently appearing in Treeherder because they're being submitted against the wrong repository name. This should fix it. /cc @stephendonner 